### PR TITLE
Revert node 18 changes

### DIFF
--- a/.github/workflows/nodeCI.yml
+++ b/.github/workflows/nodeCI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, windows-latest]
-        node: [18]
+        node: [16]
         include:
         - os: windows-latest
           commandPrefix: ''

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   "funding": "https://github.com/sponsors/MatthijsBurgh",
   "scripts": {
     "test:ci": "yarn run test:jest --runInBand --coverage && yarn run test:playwright",
-    "test:jest": "cross-env env NODE_OPTIONS=--openssl-legacy-provider jest",
-    "test:playwright": "cross-env env NODE_OPTIONS=--openssl-legacy-provider playwright test",
+    "test:jest": "jest",
+    "test:playwright": "playwright test",
     "test": "yarn run test:jest && yarn run test:playwright",
     "pretest:ci": "yarn run pretest",
     "pretest": "rimraf --glob __tests__/projects/*",
     "lint": "eslint .",
-    "docs:dev": "cross-env env NODE_OPTIONS=--openssl-legacy-provider vuepress dev docs",
-    "docs:build": "cross-env env NODE_OPTIONS=--openssl-legacy-provider vuepress build docs",
-    "docs:deploy": "cross-env env NODE_OPTIONS=--openssl-legacy-provider node ./deployDocs.js"
+    "docs:dev": "vuepress dev docs",
+    "docs:build": "vuepress build docs",
+    "docs:deploy": "node ./deployDocs.js"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
Serve is not working in separate projects.

As node is complaining about the `--openssl-legacy-provider` option in `NODE_OPTIONS`. This is required for webpack 4. So for now going back to node 16 is the only option.